### PR TITLE
190 게임매니저의 남은 플레이타임 남은 인원 동기화

### DIFF
--- a/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
+++ b/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
@@ -65,7 +65,7 @@ public class SystemUIManager : MonoBehaviour
 
 
         GameManager.currentTime.OnValueChanged += UpdateGameLifeTime;
-        GameManager.PlayerCountChange += UpdateRestPlayer;
+        GameManager.alivePlayCount.OnValueChanged += UpdateRestPlayer;
         GameManager.OnWinnerChanged += UpdateLastPlayer;
         GameManager.OnGameStateChanged += UpdateGameState; 
         gameEndPanel.SetActive(false);
@@ -86,7 +86,7 @@ public class SystemUIManager : MonoBehaviour
         GameLifeTimeText.text = $"{(int)minutes} : {(int)seconds}";
     }
 
-    private void UpdateRestPlayer(int inCurrentPlayer)
+    private void UpdateRestPlayer(int pre, int inCurrentPlayer)
     {
         RestPlayerText.text = $" Rest : {inCurrentPlayer}";
     }

--- a/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
+++ b/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
@@ -63,7 +63,8 @@ public class SystemUIManager : MonoBehaviour
             Debug.LogError("GameLifeTimeText∞° Null¿”");
         }
 
-        GameManager.GamePlayTimeChange += UpdateGameLifeTime;
+
+        GameManager.currentTime.OnValueChanged += UpdateGameLifeTime;
         GameManager.PlayerCountChange += UpdateRestPlayer;
         GameManager.OnWinnerChanged += UpdateLastPlayer;
         GameManager.OnGameStateChanged += UpdateGameState; 
@@ -77,7 +78,7 @@ public class SystemUIManager : MonoBehaviour
         unityTransport = NetworkManager.Singleton.GetComponent<UnityTransport>();
     }
 
-    private void UpdateGameLifeTime(float inCurrentTime)
+    private void UpdateGameLifeTime(float pre, float inCurrentTime)
     {
         minutes = inCurrentTime / 60;
         seconds = inCurrentTime % 60;


### PR DESCRIPTION
[[Feature] 남은시간 네트워크 벨류로 동기화]
GameManager.cs
- 남은 시간 변화는 서버에서만 카운트
- 남은시간 onChanage에 기존 시간변화 이벤트를 구독
- 키로 시작하던 StartGame 제거
SystemUIManager.cs
- GamePlayTimeChange 이벤트 구독 제거
- currenttime 네트워크벨류 체인지 이벤트 구독

[[Feature] 생존자수 동기화]
GameManager.cs
- 생존자수 NetworkValues - alivePlayCount
-PlayerCountChange 제거
- 위 이벤트 호출하던부분 값을 alivePlayCount 변경
SystemUIManager.cs
 - playerCountChage 이벤트 구독에서
 - 네트워크 벨류 이벤트로 구독