### PR TITLE
[Fix] 플레이어 사망시 입력 차단처리, 시스템 UI 버그

### DIFF
--- a/ProjectK/Assets/Prefabs/UI/InGameUI.prefab
+++ b/ProjectK/Assets/Prefabs/UI/InGameUI.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -227,7 +227,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 6691160767105613879}
   m_HandleRect: {fileID: 0}
@@ -390,4 +390,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2d77bec68c6a0c4aa6d98ead9125a74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerStat: {fileID: 0}
+  playerController: {fileID: 0}

--- a/ProjectK/Assets/Prefabs/UI/PlayerUI.prefab
+++ b/ProjectK/Assets/Prefabs/UI/PlayerUI.prefab
@@ -323,7 +323,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 5886801066715929550}
   m_HandleRect: {fileID: 0}
@@ -505,7 +505,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -673,7 +673,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 3041339159234479003}
   m_HandleRect: {fileID: 0}
@@ -1086,7 +1086,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.927191, b: 0, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/ProjectK/Assets/Scripts/InputManager/InputManager.cs
+++ b/ProjectK/Assets/Scripts/InputManager/InputManager.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 /// 플레이어 입력을 해석하고 로컬 플레이어에게만 전달하는 전역 입력 처리기
 /// </summary>
 
-public class InputManager : NetworkBehaviour
+public class InputManager : MonoBehaviour
 {
     public static InputManager Instance { get; private set; }
 
@@ -174,16 +174,6 @@ public class InputManager : NetworkBehaviour
             RegisterLocalPlayer(inPlayerController);
         }
         Logger.Error($"플레이어 상태 변경 {localPlayerState} -> " + inLocalPlayerState);
-        ChangeStateRpc(inPlayerController.GetNetworkNumber(), inLocalPlayerState);
+        localPlayerState = inLocalPlayerState;
     }
-
-    [Rpc(SendTo.Everyone)]
-    private void ChangeStateRpc(uint inPlayerNumber, PlayerState inChangeState)
-    {
-        if(inPlayerNumber == (NetworkManager.Singleton.LocalClientId + 1))
-        {
-            localPlayerState = inChangeState;
-        }
-    }
-
 }

--- a/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
+++ b/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
@@ -5,7 +5,7 @@ using Unity.Netcode;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 
-public class SystemUIManager : NetworkBehaviour
+public class SystemUIManager : MonoBehaviour
 {
     [Header("GameLifeTime")]
     private TextMeshProUGUI GameLifeTimeText;
@@ -121,12 +121,11 @@ public class SystemUIManager : NetworkBehaviour
       //  Debug.Log("데쓰 업그레이드" + NetworkManager.Singleton.LocalClientId +"번 클라에서 확인");
         if (inState == PlayerState.Die)
         {
-            PlayerDieRpc(inPlayerController.GetNetworkNumber());
+            PlayerDie(inPlayerController.GetNetworkNumber());
         }
     }
 
-    [Rpc(SendTo.Everyone)]
-    private void PlayerDieRpc(uint inPlayerNumber)
+    private void PlayerDie(uint inPlayerNumber)
     {
       //  Debug.Log(inPlayerNumber-1 + "죽었다고 들어옴" + NetworkManager.Singleton.LocalClientId + "번 클라에서 확인");
       // playerNumber를 매길때는 1부터, Localclient는 0번부터 시작인데, SetNumber도 문제고


### PR DESCRIPTION
1. 체력 슬라이더의 Interactable 비활성화 (슬라이더 상호작용 막기)
2. 인풋매니저.cs NetworkBehaviour 상속을 MonoBehaviour으로 바꿈
3. 시스템UI매니저.cs NetworkBehaviour 상속을 MonoBehaviour로 바꿈
4. GameManager.cs 의 LocalPlayerState 이벤트를 Rpc(SendTo.Everyone)로 호출
5. GameManager.cs 의 OnWinnerChanged 이벤트를 SendTo.Everyone으로 호출