### PR TITLE
246 내케릭터 비교 버그

### DIFF
--- a/ProjectK/Assets/Scripts/GameManager/GameManager.cs
+++ b/ProjectK/Assets/Scripts/GameManager/GameManager.cs
@@ -202,7 +202,7 @@ public class GameManager : NetworkBehaviour
     private void NotifyPlayerStateChangedRpc(uint inPlayerNumber, PlayerState inPlayerState)
     {
         PlayerController playerController = GetPlayer(inPlayerNumber);
-        if (inPlayerNumber == (NetworkManager.Singleton.LocalClientId + 1))
+        if (inPlayerNumber == GetMyPlayerNumber())
         {
             LocalPlayerState?.Invoke(playerController, inPlayerState);
         }

--- a/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
+++ b/ProjectK/Assets/Scripts/UI/SystemUI/SystemUIManager.cs
@@ -135,7 +135,7 @@ public class SystemUIManager : MonoBehaviour
     {
       // playerNumber를 매길때는 1부터, Localclient는 0번부터 시작인데, SetNumber도 문제고
       // LocalClientId 를 쓰면 좋은데 얘 값은 uLong 이걸 쓰는 변수가 uInt로 너무많은 변수가 있어서 로컬클라에 +1 
-        if(inPlayerNumber == (NetworkManager.Singleton.LocalClientId + 1))
+        if(inPlayerNumber == GameManager.Instance.GetMyPlayerNumber())
         {
             PlayerDieText.text = "플레이어" + (inPlayerNumber) + "사망";
 


### PR DESCRIPTION
[[Feature] 내 케릭터 넘버 반환하기]
1. 게임 케릭터 등록할때 내케릭터 할당
2. 게임 케릭터 스폰시 각 내케릭터에도 번호가 세팅됨
3. GetMyPlayerNumber로 내 케릭터 넘버를 가져옴

[ClidetNumber랑 비교하던부분 모두 수정]